### PR TITLE
Set package name to be defined by child project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@pagopa/io-functions-template",
+  "name": "@pagopa/<YOUR PACKAGE NAME>",
   "description": "",
   "author": "IO team",
-  "repository": "https://github.com/pagoPA/io-functions-template",
+  "repository": "https://github.com/pagoPA/<YOUR PROJECT NAME>",
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@pagopa/<YOUR PACKAGE NAME>",
   "description": "",
   "author": "IO team",
-  "repository": "https://github.com/pagoPA/<YOUR PROJECT NAME>",
+  "repository": "https://github.com/pagopa/<YOUR PROJECT NAME>",
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Placeholders has been defined in package.json to avoid child project not renaming the project