### PR TITLE
[#IP-86] tslint to eslint migration - removed global ignores

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
       "**/__tests__/*",
       "**/__mocks__/*",
       "*.d.ts",
-      "*.js"
+      "*.js",
+      "Dangerfile.ts"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -19,8 +20,5 @@ module.exports = {
   "extends": [
       "@pagopa/eslint-config/strong",
   ],
-  "rules": {
-    "@typescript-eslint/naming-convention": "off",
-    "prefer-arrow/prefer-arrow-functions": "off",
-  }
+  "rules": {}
 };

--- a/Dangerfile.ts
+++ b/Dangerfile.ts
@@ -1,7 +1,6 @@
 // import custom DangerJS rules
 // see http://danger.systems/js
 // see https://github.com/teamdigitale/danger-plugin-digitalcitizenship/
-// tslint:disable-next-line:prettier
 import checkDangers from "@pagopa/danger-custom-rules";
 
 checkDangers();

--- a/HttpTriggerFunction/__tests__/handler.test.ts
+++ b/HttpTriggerFunction/__tests__/handler.test.ts
@@ -1,11 +1,10 @@
 /* tslint:disable: no-any */
 
-import { HttpHandler } from "../handler";
+import { httpHandler } from "../handler";
 
 describe("HttpCtrl", () => {
   it("should return a string when the query parameter is provided", async () => {
-    const httpHandler = HttpHandler();
-    const response = await httpHandler({} as any, {} as any, "param");
+    const response = await httpHandler()({} as any, {} as any, "param");
     expect(response.kind).toBe("IResponseSuccessJson");
   });
 });

--- a/HttpTriggerFunction/handler.ts
+++ b/HttpTriggerFunction/handler.ts
@@ -22,7 +22,7 @@ import {
 type IHttpHandler = (
   context: Context,
   userAttrs: IAzureUserAttributes,
-  param: string
+  param: unknown
 ) => Promise<
   | IResponseSuccessJson<{
       readonly message: string;
@@ -30,25 +30,25 @@ type IHttpHandler = (
   | IResponseErrorNotFound
 >;
 
-export function HttpHandler(): IHttpHandler {
-  return async (
-    ctx,
-    userAttrs,
-    param
-  ): Promise<
-    IResponseSuccessJson<{
-      readonly message: string;
-    }>
-  > =>
-    ResponseSuccessJson({
-      headers: ctx.req?.headers,
-      message: `Hello ${param} !`,
-      user: userAttrs
-    });
-}
+export const httpHandler = (): IHttpHandler => async (
+  ctx,
+  userAttrs,
+  param
+): Promise<
+  IResponseSuccessJson<{
+    readonly message: string;
+  }>
+> =>
+  ResponseSuccessJson({
+    headers: ctx.req?.headers,
+    message: `Hello ${param} !`,
+    user: userAttrs
+  });
 
-export function HttpCtrl(serviceModel: ServiceModel): express.RequestHandler {
-  const handler = HttpHandler();
+export const httpCtrl = (
+  serviceModel: ServiceModel
+): express.RequestHandler => {
+  const handler = httpHandler();
 
   const middlewaresWrap = withRequestMiddlewares(
     ContextMiddleware(),
@@ -57,4 +57,4 @@ export function HttpCtrl(serviceModel: ServiceModel): express.RequestHandler {
   );
 
   return wrapRequestHandler(middlewaresWrap(handler));
-}
+};

--- a/HttpTriggerFunction/index.ts
+++ b/HttpTriggerFunction/index.ts
@@ -13,7 +13,7 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbClient } from "../utils/cosmosdb";
-import { HttpCtrl } from "./handler";
+import { httpCtrl } from "./handler";
 
 //
 //  CosmosDB initialization
@@ -39,15 +39,15 @@ const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.get("/some/path/:someParam", HttpCtrl(serviceModel));
+app.get("/some/path/:someParam", httpCtrl(serviceModel));
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 
 // Binds the express app to an Azure Function handler
-function httpStart(context: Context): void {
+const httpStart = (context: Context): void => {
   logger = context.log;
   setAppContext(app, context);
   azureFunctionHandler(context);
-}
+};
 
 export default httpStart;

--- a/Info/__tests__/handler.test.ts
+++ b/Info/__tests__/handler.test.ts
@@ -1,18 +1,18 @@
 import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
 import { HealthCheck, HealthProblem } from "../../utils/healthcheck";
-import { InfoHandler } from "../handler";
+import { infoHandler } from "../handler";
 
 afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe("InfoHandler", () => {
+describe("infoHandler", () => {
   it("should return an internal error if the application is not healthy", async () => {
     const healthCheck: HealthCheck = fromLeft([
       "failure 1" as HealthProblem<"Config">,
       "failure 2" as HealthProblem<"Config">
     ]);
-    const handler = InfoHandler(healthCheck);
+    const handler = infoHandler(healthCheck);
 
     const response = await handler();
 
@@ -21,7 +21,7 @@ describe("InfoHandler", () => {
 
   it("should return a success if the application is healthy", async () => {
     const healthCheck: HealthCheck = taskEither.of(true);
-    const handler = InfoHandler(healthCheck);
+    const handler = infoHandler(healthCheck);
 
     const response = await handler();
 

--- a/Info/handler.ts
+++ b/Info/handler.ts
@@ -18,22 +18,24 @@ type InfoHandler = () => Promise<
   IResponseSuccessJson<IInfo> | IResponseErrorInternal
 >;
 
-export function InfoHandler(healthCheck: HealthCheck): InfoHandler {
-  return (): Promise<IResponseSuccessJson<IInfo> | IResponseErrorInternal> =>
-    healthCheck
-      .fold<IResponseSuccessJson<IInfo> | IResponseErrorInternal>(
-        problems => ResponseErrorInternal(problems.join("\n\n")),
-        _ =>
-          ResponseSuccessJson({
-            name: packageJson.name,
-            version: packageJson.version
-          })
-      )
-      .run();
-}
+export const infoHandler = (
+  healthCheck: HealthCheck
+): InfoHandler => (): Promise<
+  IResponseSuccessJson<IInfo> | IResponseErrorInternal
+> =>
+  healthCheck
+    .fold<IResponseSuccessJson<IInfo> | IResponseErrorInternal>(
+      problems => ResponseErrorInternal(problems.join("\n\n")),
+      _ =>
+        ResponseSuccessJson({
+          name: packageJson.name,
+          version: packageJson.version
+        })
+    )
+    .run();
 
-export function Info(): express.RequestHandler {
-  const handler = InfoHandler(checkApplicationHealth());
+export const info = (): express.RequestHandler => {
+  const handler = infoHandler(checkApplicationHealth());
 
   return wrapRequestHandler(handler);
-}
+};

--- a/Info/index.ts
+++ b/Info/index.ts
@@ -3,14 +3,14 @@ import * as express from "express";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
-import { Info } from "./handler";
+import { info } from "./handler";
 
 // Setup Express
 const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.get("/api/v1/info", Info());
+app.get("/api/v1/info", info());
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx --cache",
-    "lint-autofix": "eslint . -c .eslintrc.js --ext .ts,.tsx --fix",
     "lint-api": "oval validate -p openapi/index.yaml",
     "dist:modules": "modclean -r -n default:safe && yarn install --production",
     "predeploy": "npm-run-all generate build dist:*",
@@ -60,7 +59,8 @@
     "io-functions-express": "^1.1.0",
     "io-ts": "1.8.5",
     "italia-ts-commons": "^8.6.0",
-    "winston": "^3.2.1"
+    "winston": "^3.2.1",
+    "node-fetch": "^2.6.0"
   },
   "resolutions": {
     "handlebars": "~4.5.3",

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -6,12 +6,14 @@
  */
 
 import * as t from "io-ts";
+import { ValidationError } from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
 // global app configuration
-export type IConfig = t.TypeOf<typeof IConfig>;
-export const IConfig = t.interface({
+export type IConfig = t.TypeOf<typeof iConfig>;
+export const iConfig = t.interface({
+  /* eslint-disable @typescript-eslint/naming-convention */
   AzureWebJobsStorage: NonEmptyString,
 
   COSMOSDB_KEY: NonEmptyString,
@@ -21,10 +23,11 @@ export const IConfig = t.interface({
   QueueStorageConnection: NonEmptyString,
 
   isProduction: t.boolean
+  /* eslint-enable @typescript-eslint/naming-convention */
 });
 
 // No need to re-evaluate this object for each call
-const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
+const errorOrConfig: t.Validation<IConfig> = iConfig.decode({
   ...process.env,
   isProduction: process.env.NODE_ENV === "production"
 });
@@ -35,9 +38,7 @@ const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
  *
  * @returns either the configuration values or a list of validation errors
  */
-export function getConfig(): t.Validation<IConfig> {
-  return errorOrConfig;
-}
+export const getConfig = (): t.Validation<IConfig> => errorOrConfig;
 
 /**
  * Read the application configuration and check for invalid values.
@@ -46,8 +47,7 @@ export function getConfig(): t.Validation<IConfig> {
  * @returns the configuration values
  * @throws validation errors found while parsing the application configuration
  */
-export function getConfigOrThrow(): IConfig {
-  return errorOrConfig.getOrElseL(errors => {
+export const getConfigOrThrow = (): IConfig =>
+  errorOrConfig.getOrElseL((errors: ReadonlyArray<ValidationError>) => {
     throw new Error(`Invalid configuration: ${readableReport(errors)}`);
   });
-}

--- a/utils/healthcheck.ts
+++ b/utils/healthcheck.ts
@@ -20,7 +20,7 @@ import fetch from "node-fetch";
 import { getConfig, IConfig } from "./config";
 
 type ProblemSource = "AzureCosmosDB" | "AzureStorage" | "Config" | "Url";
-// eslint-disable-next-line functional/prefer-readonly-type
+// eslint-disable-next-line functional/prefer-readonly-type, @typescript-eslint/naming-convention
 export type HealthProblem<S extends ProblemSource> = string & { __source: S };
 export type HealthCheck<
   S extends ProblemSource = ProblemSource,


### PR DESCRIPTION
#### List of Changes
- Removed global ignore rules from `.eslintrc.js`
- Ignored or fixed linting locally
- Added node-fetch to dependencies to make build work

#### Motivation and Context
We want to migrate to eslint because tslint is deprecated.

#### How Has This Been Tested?
It has been tested by performing:
- yarn install --frozen-lockfile
- yarn build
- yarn lint
- yarn test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
