### PR TITLE
[#IP-86] tslint to eslint migration

### DIFF
--- a/HttpTriggerFunction/__tests__/handler.test.ts
+++ b/HttpTriggerFunction/__tests__/handler.test.ts
@@ -1,10 +1,10 @@
 /* tslint:disable: no-any */
 
-import { httpHandler } from "../handler";
+import { HttpHandler } from "../handler";
 
 describe("HttpCtrl", () => {
   it("should return a string when the query parameter is provided", async () => {
-    const response = await httpHandler()({} as any, {} as any, "param");
+    const response = await HttpHandler()({} as any, {} as any, "param");
     expect(response.kind).toBe("IResponseSuccessJson");
   });
 });

--- a/HttpTriggerFunction/handler.ts
+++ b/HttpTriggerFunction/handler.ts
@@ -30,6 +30,7 @@ type IHttpHandler = (
   | IResponseErrorNotFound
 >;
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const HttpHandler = (): IHttpHandler => async (
   ctx,
   userAttrs,
@@ -45,6 +46,7 @@ export const HttpHandler = (): IHttpHandler => async (
     user: userAttrs
   });
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const HttpCtrl = (
   serviceModel: ServiceModel
 ): express.RequestHandler => {

--- a/HttpTriggerFunction/handler.ts
+++ b/HttpTriggerFunction/handler.ts
@@ -30,7 +30,7 @@ type IHttpHandler = (
   | IResponseErrorNotFound
 >;
 
-export const httpHandler = (): IHttpHandler => async (
+export const HttpHandler = (): IHttpHandler => async (
   ctx,
   userAttrs,
   param
@@ -45,10 +45,10 @@ export const httpHandler = (): IHttpHandler => async (
     user: userAttrs
   });
 
-export const httpCtrl = (
+export const HttpCtrl = (
   serviceModel: ServiceModel
 ): express.RequestHandler => {
-  const handler = httpHandler();
+  const handler = HttpHandler();
 
   const middlewaresWrap = withRequestMiddlewares(
     ContextMiddleware(),

--- a/HttpTriggerFunction/index.ts
+++ b/HttpTriggerFunction/index.ts
@@ -13,7 +13,7 @@ import createAzureFunctionHandler from "io-functions-express/dist/src/createAzur
 
 import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbClient } from "../utils/cosmosdb";
-import { httpCtrl } from "./handler";
+import { HttpCtrl } from "./handler";
 
 //
 //  CosmosDB initialization
@@ -39,7 +39,7 @@ const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.get("/some/path/:someParam", httpCtrl(serviceModel));
+app.get("/some/path/:someParam", HttpCtrl(serviceModel));
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/Info/__tests__/handler.test.ts
+++ b/Info/__tests__/handler.test.ts
@@ -1,18 +1,18 @@
 import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
 import { HealthCheck, HealthProblem } from "../../utils/healthcheck";
-import { infoHandler } from "../handler";
+import { InfoHandler } from "../handler";
 
 afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe("infoHandler", () => {
+describe("InfoHandler", () => {
   it("should return an internal error if the application is not healthy", async () => {
     const healthCheck: HealthCheck = fromLeft([
       "failure 1" as HealthProblem<"Config">,
       "failure 2" as HealthProblem<"Config">
     ]);
-    const handler = infoHandler(healthCheck);
+    const handler = InfoHandler(healthCheck);
 
     const response = await handler();
 
@@ -21,7 +21,7 @@ describe("infoHandler", () => {
 
   it("should return a success if the application is healthy", async () => {
     const healthCheck: HealthCheck = taskEither.of(true);
-    const handler = infoHandler(healthCheck);
+    const handler = InfoHandler(healthCheck);
 
     const response = await handler();
 

--- a/Info/handler.ts
+++ b/Info/handler.ts
@@ -18,7 +18,7 @@ type InfoHandler = () => Promise<
   IResponseSuccessJson<IInfo> | IResponseErrorInternal
 >;
 
-export const infoHandler = (
+export const InfoHandler = (
   healthCheck: HealthCheck
 ): InfoHandler => (): Promise<
   IResponseSuccessJson<IInfo> | IResponseErrorInternal
@@ -34,8 +34,8 @@ export const infoHandler = (
     )
     .run();
 
-export const info = (): express.RequestHandler => {
-  const handler = infoHandler(checkApplicationHealth());
+export const Info = (): express.RequestHandler => {
+  const handler = InfoHandler(checkApplicationHealth());
 
   return wrapRequestHandler(handler);
 };

--- a/Info/handler.ts
+++ b/Info/handler.ts
@@ -18,6 +18,7 @@ type InfoHandler = () => Promise<
   IResponseSuccessJson<IInfo> | IResponseErrorInternal
 >;
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const InfoHandler = (
   healthCheck: HealthCheck
 ): InfoHandler => (): Promise<
@@ -34,6 +35,7 @@ export const InfoHandler = (
     )
     .run();
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const Info = (): express.RequestHandler => {
   const handler = InfoHandler(checkApplicationHealth());
 

--- a/Info/index.ts
+++ b/Info/index.ts
@@ -3,14 +3,14 @@ import * as express from "express";
 import { secureExpressApp } from "io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
-import { info } from "./handler";
+import { Info } from "./handler";
 
 // Setup Express
 const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.get("/api/v1/info", info());
+app.get("/api/v1/info", Info());
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -12,6 +12,7 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
 // global app configuration
 export type IConfig = t.TypeOf<typeof IConfig>;
+// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/ban-types
 export const IConfig = t.interface({
   /* eslint-disable @typescript-eslint/naming-convention */
   AzureWebJobsStorage: NonEmptyString,

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -11,8 +11,8 @@ import { readableReport } from "italia-ts-commons/lib/reporters";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
 // global app configuration
-export type IConfig = t.TypeOf<typeof iConfig>;
-export const iConfig = t.interface({
+export type IConfig = t.TypeOf<typeof IConfig>;
+export const IConfig = t.interface({
   /* eslint-disable @typescript-eslint/naming-convention */
   AzureWebJobsStorage: NonEmptyString,
 
@@ -27,7 +27,7 @@ export const iConfig = t.interface({
 });
 
 // No need to re-evaluate this object for each call
-const errorOrConfig: t.Validation<IConfig> = iConfig.decode({
+const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
   ...process.env,
   isProduction: process.env.NODE_ENV === "production"
 });


### PR DESCRIPTION
#### List of Changes
- Restored previous const names
- Disabled lint errors locally

#### Motivation and Context
We want to preserve old const naming even if there are lint errors to keep the coherence in the codebase.

#### How Has This Been Tested?
It has been tested by performing:
- yarn install --frozen-lockfile
- yarn build
- yarn lint
- yarn test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
