### PR TITLE
[#IP-86] Updated linting rules and removed disabling comments

### DIFF
--- a/HttpTriggerFunction/handler.ts
+++ b/HttpTriggerFunction/handler.ts
@@ -30,7 +30,6 @@ type IHttpHandler = (
   | IResponseErrorNotFound
 >;
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const HttpHandler = (): IHttpHandler => async (
   ctx,
   userAttrs,
@@ -46,7 +45,6 @@ export const HttpHandler = (): IHttpHandler => async (
     user: userAttrs
   });
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const HttpCtrl = (
   serviceModel: ServiceModel
 ): express.RequestHandler => {

--- a/Info/handler.ts
+++ b/Info/handler.ts
@@ -18,7 +18,6 @@ type InfoHandler = () => Promise<
   IResponseSuccessJson<IInfo> | IResponseErrorInternal
 >;
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const InfoHandler = (
   healthCheck: HealthCheck
 ): InfoHandler => (): Promise<
@@ -35,7 +34,6 @@ export const InfoHandler = (
     )
     .run();
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const Info = (): express.RequestHandler => {
   const handler = InfoHandler(checkApplicationHealth());
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@azure/functions": "^1.2.2",
     "@pagopa/danger-custom-rules": "^2.0.3",
-    "@pagopa/eslint-config": "^1.1.1",
+    "@pagopa/eslint-config": "^1.3.1",
     "@types/express": "^4.17.9",
     "@types/jest": "^24.0.15",
     "@types/node-fetch": "^2.5.7",
@@ -59,8 +59,8 @@
     "io-functions-express": "^1.1.0",
     "io-ts": "1.8.5",
     "italia-ts-commons": "^8.6.0",
-    "winston": "^3.2.1",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "winston": "^3.2.1"
   },
   "resolutions": {
     "handlebars": "~4.5.3",

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -12,9 +12,8 @@ import { NonEmptyString } from "italia-ts-commons/lib/strings";
 
 // global app configuration
 export type IConfig = t.TypeOf<typeof IConfig>;
-// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/ban-types
 export const IConfig = t.interface({
-  /* eslint-disable @typescript-eslint/naming-convention */
   AzureWebJobsStorage: NonEmptyString,
 
   COSMOSDB_KEY: NonEmptyString,
@@ -24,7 +23,6 @@ export const IConfig = t.interface({
   QueueStorageConnection: NonEmptyString,
 
   isProduction: t.boolean
-  /* eslint-enable @typescript-eslint/naming-convention */
 });
 
 // No need to re-evaluate this object for each call

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,11 +618,11 @@
     auto-changelog "^2.2.1"
     danger-plugin-yarn "^1.2.1"
     pivotaljs "^1.0.3"
-    
-"@pagopa/eslint-config@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/eslint-config/-/eslint-config-1.1.1.tgz#09fdfa59708f44996c042451d4d16a624b276bcb"
-  integrity sha512-b4MBnPWFj1I/O3wpQfR475BoLcB7Nmze67eqLl+J1t7ajFKPi4FF8k7+Xpfct6Z1ziVSTYVjQgMuoBJRHADcrA==
+
+"@pagopa/eslint-config@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@pagopa/eslint-config/-/eslint-config-1.3.1.tgz#0c41ae939aa6d740fbc8d8dbe2c4395aa2ceaf95"
+  integrity sha512-UZvYeN1ivU5qMZDGXI/JlEoQ+2SMZfTjOeoZBd6Wm5UC98b6bYBG4ov3QmluM6TxsLLMyBALgP55lkg56+VjRw==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.10.0"
     "@typescript-eslint/eslint-plugin-tslint" "^4.10.0"
@@ -6898,17 +6898,17 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-parse-diff@^0.7.0:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/parse-diff/-/parse-diff-0.7.1.tgz#9b7a2451c3725baf2c87c831ba192d40ee2237d4"
-  integrity sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-diff@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/parse-diff/-/parse-diff-0.7.1.tgz#9b7a2451c3725baf2c87c831ba192d40ee2237d4"
+  integrity sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg==
 
 parse-entities@^1.1.0:
   version "1.2.2"


### PR DESCRIPTION
#### List of Changes
- Updated eslint-rules to 1.3.1
- Removed useless rule disabling comment

#### Motivation and Context
We want to have as less rule disabling comments as possible for @typescript-eslint/naming-convention rule.

#### How Has This Been Tested?
It has been tested by performing:
- yarn install --frozen-lockfile
- yarn build
- yarn lint
- yarn test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

